### PR TITLE
docs: remove unnecessary async keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ test('should show count text  when rendered', () => {
   expect(queryByTestId('count').textContent).toBe("10");
 })
 
-test('should add count when click add button text', async () => {
+test('should add count when click add button text', () => {
     const { queryByTestId } = render(TestTag, {count: 1});
     expect(queryByTestId('count').textContent).toBe("1");
     fireEvent.click(queryByTestId('button'))


### PR DESCRIPTION
Hey! 

I was just browsing your repo and found out there is unnecessary `async` keyword in your `README`. This PR removes it.